### PR TITLE
Replace smart quote character U+2019 with straight quote

### DIFF
--- a/alex/ProfanityLikely.yml
+++ b/alex/ProfanityLikely.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: Don't use '%s', it’s profane.
+message: Don't use '%s', it's profane.
 level: warning
 ignorecase: true
 tokens:

--- a/alex/ProfanityUnlikely.yml
+++ b/alex/ProfanityUnlikely.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: Be careful with '%s', it’s profane in some cases.
+message: Be careful with '%s', it's profane in some cases.
 level: warning
 ignorecase: true
 tokens:


### PR DESCRIPTION
The apostrophe in both of these messages is the unicode "[right single quote](https://www.compart.com/en/unicode/U+2019)" character. 

This replaces them with a more standard [apostrophe](https://www.compart.com/en/unicode/U+0027).

Signed-off-by: Pete Lumbis <pete@upbound.io>