### PR TITLE
Remove whitespace and its variants from the list of racial words

### DIFF
--- a/alex/Race.yml
+++ b/alex/Race.yml
@@ -78,10 +78,6 @@ swap:
   towel heads: Arabs|Middle Eastern People
   tribe: society|community
   white list: passlist|alrightlist|safelist|allow list
-  white space: space|blank
-  white spaces: space|blank
   whitelist: passlist|alrightlist|safelist|allow list
   whitelisted: passlisted|alrightlisted|safelisted|allow-listed
   whitelisting: passlisting|alrightlisting|safelisting|allow-listing
-  whitespace: space|blank
-  whitespaces: space|blank


### PR DESCRIPTION
The 'white' in 'whitespace' refers to the color of paper, not of skin. Thus it is not related to race.