### PR TITLE
Update Ablist.yml for PwMS language

### DIFF
--- a/alex/Ablist.yml
+++ b/alex/Ablist.yml
@@ -213,7 +213,7 @@ swap:
     disabilities
   suffering from injuries: sustain injuries|receive injuries
   suffering from intellectual disabilities: person with an intellectual disability
-  suffering from multiple sclerosis: person who has multiple sclerosis
+  suffering from multiple sclerosis: person with multiple sclerosis
   suffering from polio: polio|person who had polio
   suffering from psychosis: person with a psychotic condition|person with psychosis
   suffering from schizophrenia: person with schizophrenia


### PR DESCRIPTION
The commonly accepted language by both the scientific and the patient communities is PwMS (person [living] w/ multiple sclerosis). This is both the widely used, academically accepted and patient-preferred formulation.

See [here](https://www.msard-journal.com/article/S2211-0348(22)00269-3/abstract) or [here](https://www.sciencedirect.com/science/article/pii/S2211034823005333), for academic examples, and [here](https://msinthe21stcentury.com/us/about-ms21/category/pwms/), for a patient perspective.